### PR TITLE
hotfix: userRoute.get param name typo

### DIFF
--- a/server/routes/userRoute.ts
+++ b/server/routes/userRoute.ts
@@ -7,7 +7,7 @@ userRoute.get('/findAll/:githubId', UserController.fullUserDetails, (req, res) =
 	res.status(200).json(res.locals.user);
 });
 
-userRoute.get('/:githubId', UserController.getUser, (req, res) => {
+userRoute.get('/:userId', UserController.getUser, (req, res) => {
 	res.status(200).json(res.locals.user);
 });
 


### PR DESCRIPTION


## Description

hotfix to previous merge - accidental typo in the name of userRoute.get('/:userId') endpoint was preventing it from functioning properly. 

hotfix included, tested to ensure it is now a working route according to agreed-upon endpoint behavior.

