### PR TITLE
Feat: Direct Link capabilities for existing page's tree

### DIFF
--- a/server/controllers/pageController.ts
+++ b/server/controllers/pageController.ts
@@ -1,4 +1,5 @@
 import PageModel from '../models/pageModel';
+import ProjectModel from '../models/projectModel';
 import { pageController } from '../type';
 
 const PageController = {} as pageController;
@@ -12,6 +13,10 @@ PageController.getPage = async (req, res, next) => {
     //if no page found --> DB returns null
     if (!page) return res.status(204).send('No page tree found.');
 
+    const relatedProject = await ProjectModel.findById({_id: page.projectId})
+    if (!relatedProject) return res.status(204).send('Incomplete page tree found - missing valid project.');
+
+    res.locals.projectName = relatedProject.projectName;
     res.locals.page = page;
     return next();
   } catch (err) {

--- a/server/routes/pageRoute.ts
+++ b/server/routes/pageRoute.ts
@@ -11,7 +11,9 @@ pageRoute.get(
   '/:pageId',
   PageController.getPage,
   (req: Request, res: Response): void => {
-    res.status(200).json(res.locals.page);
+    res
+      .status(200)
+      .json({ page: res.locals.page, projectName: res.locals.projectName });
   }
 );
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,12 +1,16 @@
 import { Routes, Route, useLocation, useNavigate } from 'react-router-dom';
 import './css/App.css';
-import Home from './pages/Home';
+import { useEffect, useState } from 'react';
+import { UserInfo } from './types';
+//COMPONENTS
+import AccountMenu from './components/AccountMenu';
 import BtnDownload from './components/BtnDownload';
 import OAuth from './components/OAuth';
-import { useEffect, useState } from 'react';
-import AccountMenu from './components/AccountMenu';
+
+//PAGES
 import MainDashboard from './pages/MainDashboard';
-import { UserInfo } from './types';
+import Home from './pages/Home';
+import DirectLinkTreeDisplay from './pages/DirectLinkTreeDisplay'
 
 function App() {
   const navigate = useNavigate();
@@ -24,7 +28,6 @@ function App() {
 
   useEffect(() => {
     const checkLoginStatus = async () => {
-
       try {
         const response = await fetch(
           'https://localhost:3333/auth/checkstatus',
@@ -78,6 +81,10 @@ function App() {
         <Route
           path='/dashboard'
           element={userInfo && <MainDashboard userInfo={userInfo} />}
+        />
+        <Route
+          path='/treedirect/:pageId'
+          element={<DirectLinkTreeDisplay/>}
         />
       </Routes>
       {/* {Update Footer with copyright notice, privacy policy link, sitemap, logo, contact info, social media icons} */}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,7 +10,7 @@ import OAuth from './components/OAuth';
 //PAGES
 import MainDashboard from './pages/MainDashboard';
 import Home from './pages/Home';
-import DirectLinkTreeDisplay from './pages/DirectLinkTreeDisplay'
+import DirectLinkTreeDisplay from './pages/DirectLinkTreeDisplay';
 
 function App() {
   const navigate = useNavigate();
@@ -82,10 +82,8 @@ function App() {
           path='/dashboard'
           element={userInfo && <MainDashboard userInfo={userInfo} />}
         />
-        <Route
-          path='/treedirect/:pageId'
-          element={<DirectLinkTreeDisplay/>}
-        />
+        <Route path='/treedirect/:pageId' element={<DirectLinkTreeDisplay />} />
+        <Route path='/treedirect/' element={<DirectLinkTreeDisplay />} />
       </Routes>
       {/* {Update Footer with copyright notice, privacy policy link, sitemap, logo, contact info, social media icons} */}
       {showHeaderFooter && (

--- a/src/components/DirectLinkGenerator.tsx
+++ b/src/components/DirectLinkGenerator.tsx
@@ -16,7 +16,7 @@ function DirectLinkGenerator({ pageId }: DirectLinkGeneratorProps) {
   }, [pageId]);
 
   return (
-    <button onClick={() => handleClick()}>
+    <button id='copyDirectLink' onClick={() => handleClick()}>
       {isClicked ? 'Link copied to clipboard' : 'Share this tree!'}
     </button>
   );

--- a/src/components/DirectLinkGenerator.tsx
+++ b/src/components/DirectLinkGenerator.tsx
@@ -1,0 +1,25 @@
+import { useState, useEffect } from 'react';
+import { DirectLinkGeneratorProps } from '../types';
+
+function DirectLinkGenerator({ pageId }: DirectLinkGeneratorProps) {
+  const [isClicked, setIsClicked] = useState<boolean>(false);
+
+  //clicking the button will copy Tree-specific direct link to client's clipboard
+  const handleClick = (): void => {
+    const directLink = `https://localhost:5173/treedirect/${pageId}`;
+    navigator.clipboard.writeText(directLink);
+    setIsClicked(true);
+  };
+
+  useEffect(() => {
+    setIsClicked(false);
+  }, [pageId]);
+
+  return (
+    <button onClick={() => handleClick()}>
+      {isClicked ? 'Link copied to clipboard' : 'Share this tree!'}
+    </button>
+  );
+}
+
+export default DirectLinkGenerator;

--- a/src/css/DirectLinkTree.css
+++ b/src/css/DirectLinkTree.css
@@ -21,7 +21,7 @@
     padding: 3rem;
   }
   
-  .dashboard h2 {
+  .directLinkTree h2 {
     font-size: 2rem;
     text-align: center;
     padding-bottom: 2rem;

--- a/src/css/DirectLinkTree.css
+++ b/src/css/DirectLinkTree.css
@@ -1,0 +1,28 @@
+.enterUrl {
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-start;
+    align-items: center;
+    align-self: flex-end;
+    font-family: Hubot;
+    margin-right: 2rem;
+  }
+
+  /* ---------- Main Dashboard ---------- */
+
+.app {
+    display: grid;
+  }
+  
+  .directLinkTree {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding: 3rem;
+  }
+  
+  .dashboard h2 {
+    font-size: 2rem;
+    text-align: center;
+    padding-bottom: 2rem;
+  }

--- a/src/pages/DirectLinkTreeDisplay.tsx
+++ b/src/pages/DirectLinkTreeDisplay.tsx
@@ -52,9 +52,9 @@ function DirectLinkTreeDisplay() {
 
   return (
     <main className='directLinkTree'>
-      <h2>Accessibility (A11y) Tree Direct Link</h2>
+      <h2>Accessibility (A11y) Tree: Page For Direct Links</h2>
       {pageResults && <p>Displaying Tree for: {pageResults.url}</p>}
-      {pageResults && <p>From project: {projectName}</p>}
+      {pageResults && <p>From Project: {projectName}</p>}
       {pageResults && pageId ? (
         <div className='tabs-and-display-container'>
           <TabNavigation

--- a/src/pages/DirectLinkTreeDisplay.tsx
+++ b/src/pages/DirectLinkTreeDisplay.tsx
@@ -15,6 +15,7 @@ function DirectLinkTreeDisplay() {
   //state required for displaying a tree
   const [activeTab, setActiveTab] = useState('Full Tree');
   const [pageResults, setPageResults] = useState<PageResults | null>(null);
+  const [projectName, setProjectName] = useState<string>('');
 
   const handleclick = (e: string) => {
     setActiveTab(e);
@@ -26,7 +27,9 @@ function DirectLinkTreeDisplay() {
       try {
         const response = await fetch(`https://localhost:3333/pages/${pageId}`);
         if (response.ok) {
-          const pageDetails = await response.json();
+          const data = await response.json();
+          const pageDetails = data.page;
+          const projectName = data.projectName;
 
           //turn stringified fields of page (as stored in DB) back into JSON objects for display
           pageDetails.tree = JSON.parse(pageDetails.tree);
@@ -37,6 +40,7 @@ function DirectLinkTreeDisplay() {
           });
 
           setPageResults(pageDetails as PageResults);
+          setProjectName(projectName);
         }
       } catch (error) {
         console.error('Could not get page details: ', error);
@@ -49,9 +53,9 @@ function DirectLinkTreeDisplay() {
   return (
     <main className='directLinkTree'>
       <h2>Accessibility (A11y) Tree Direct Link</h2>
-      {pageResults && <p>Displaying Tree for page: {pageResults.url}</p>}
-
-      {pageResults ? (
+      {pageResults && <p>Displaying Tree for: {pageResults.url}</p>}
+      {pageResults && <p>From project: {projectName}</p>}
+      {pageResults && pageId ? (
         <div className='tabs-and-display-container'>
           <TabNavigation
             activeTab={activeTab}

--- a/src/pages/DirectLinkTreeDisplay.tsx
+++ b/src/pages/DirectLinkTreeDisplay.tsx
@@ -1,0 +1,73 @@
+import { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import '../css/DirectLinkTree.css';
+//TYPES
+import { PageResults } from '../types';
+
+//COMPONENTS
+import TabNavigation from '../components/TabNavigation';
+import DisplayA11yTree from '../components/DisplayA11yTree';
+
+function DirectLinkTreeDisplay() {
+  //read the projectId to display from the URL parameters
+  const { pageId } = useParams();
+
+  //state required for displaying a tree
+  const [activeTab, setActiveTab] = useState('Full Tree');
+  const [pageResults, setPageResults] = useState<PageResults | null>(null);
+
+  const handleclick = (e: string) => {
+    setActiveTab(e);
+  };
+
+  //on page load, we are fetching the relevant page based on pageId, and passing to relevant child elements
+  useEffect(() => {
+    const getPage = async () => {
+      try {
+        const response = await fetch(`https://localhost:3333/pages/${pageId}`);
+        if (response.ok) {
+          const pageDetails = await response.json();
+
+          //turn stringified fields of page (as stored in DB) back into JSON objects for display
+          pageDetails.tree = JSON.parse(pageDetails.tree);
+          pageDetails.skipLink = JSON.parse(pageDetails.skipLink);
+          pageDetails.h1 = JSON.parse(pageDetails.h1);
+          pageDetails.tabIndex = pageDetails.tabIndex.map((node: string) => {
+            return JSON.parse(node);
+          });
+
+          setPageResults(pageDetails as PageResults);
+        }
+      } catch (error) {
+        console.error('Could not get page details: ', error);
+      }
+    };
+
+    getPage();
+  }, []);
+
+  return (
+    <main className='directLinkTree'>
+      <h2>Accessibility (A11y) Tree Direct Link</h2>
+      {pageResults && <p>Displaying Tree for page: {pageResults.url}</p>}
+
+      {pageResults ? (
+        <div className='tabs-and-display-container'>
+          <TabNavigation
+            activeTab={activeTab}
+            handleTabChange={handleclick}
+            pageResults={pageResults}
+          />
+          <DisplayA11yTree activeTab={activeTab} pageResults={pageResults} />
+        </div>
+      ) : (
+        <p>
+          400 Bad Request: The direct link used does not match any Accessibility
+          Tree in our database! Please enter a valid link.
+        </p>
+      )}
+    </main>
+  );
+}
+
+export default DirectLinkTreeDisplay;

--- a/src/pages/MainDashboard.tsx
+++ b/src/pages/MainDashboard.tsx
@@ -1,13 +1,16 @@
 import { useState } from 'react';
+
+import '../css/Dashboard.css';
+import { MainDashboardProps, PageResults } from '../types';
+
+//COMPONENTS
 import FormContainer from '../components/FormContainer';
 import TabNavigation from '../components/TabNavigation';
 import DisplayA11yTree from '../components/DisplayA11yTree';
-import { MainDashboardProps } from '../types';
-import { PageResults } from '../types';
-import '../css/Dashboard.css';
+import DirectLinkGenerator from '../components/DirectLinkGenerator';
 
 function MainDashboard({ userInfo }: MainDashboardProps) {
-  const [activeTab, setActiveTab] = useState('');
+  const [activeTab, setActiveTab] = useState('Full Tree');
   const [pageResults, setPageResults] = useState<PageResults | null>(null);
 
   const handleclick = (e: string) => {
@@ -22,6 +25,7 @@ function MainDashboard({ userInfo }: MainDashboardProps) {
         setPageResults={setPageResults}
         pageResults={pageResults}
       />
+      {pageResults && <DirectLinkGenerator pageId={pageResults._id} />}
       <div className='tabs-and-display-container'>
         {pageResults && (
           <TabNavigation
@@ -30,7 +34,9 @@ function MainDashboard({ userInfo }: MainDashboardProps) {
             pageResults={pageResults}
           />
         )}
-        <DisplayA11yTree activeTab={activeTab} pageResults={pageResults} />
+        {pageResults && (
+          <DisplayA11yTree activeTab={activeTab} pageResults={pageResults} />
+        )}
       </div>
     </main>
   );

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -126,6 +126,10 @@ export interface AccountMenuProps {
   handleLogout: () => void;
 }
 
+export interface DirectLinkGeneratorProps {
+  pageId: string
+}
+
 //DB stringified types
 
 export interface DBProject {


### PR DESCRIPTION
## Linked issue/ticket

[SCRUM-79](https://mindfulmess.atlassian.net/jira/software/projects/SCRUM/boards/1?selectedIssue=SCRUM-79)

## Description

Add: Route to App for DirectLinkTreeDisplay
- This new page displays the a11y tree for an existing page within our database. This is accessible regardless of user/signin status, allowing a developer to share individual trees/pages with others.

Add: DirectLinkGenerator button to MainDashboard
-This new button generates a direct link to the currently displayed page / tree. Clicking the button copies the link to the user's clipboard. This can then be used to access the DirectLinkTreeDisplay.

Placeholder styling in place for both additions; to be revisited in the future.
